### PR TITLE
Added a node to prevent collisions during navigation based on LaserScan messages 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,11 +65,11 @@ add_definitions(-DQT_NO_KEYWORDS)
 ##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
 
 ## Generate messages in the 'msg' folder
-# add_message_files(
-#   FILES
-#   Message1.msg
-#   Message2.msg
-# )
+add_message_files(
+  FILES
+  Waypoint.msg
+  WaypointArray.msg
+)
 
 ## Generate services in the 'srv' folder
 # add_service_files(
@@ -85,11 +85,11 @@ add_definitions(-DQT_NO_KEYWORDS)
 #   Action2.action
 # )
 
-## Generate added messages and services with any dependencies listed here
-# generate_messages(
-#   DEPENDENCIES
-#   geometry_msgs#   nav_msgs#   sensor_msgs#   std_msgs
-# )
+# Generate added messages and services with any dependencies listed here
+generate_messages(
+  DEPENDENCIES
+  std_msgs geometry_msgs
+)
 
 ################################################
 ## Declare ROS dynamic reconfigure parameters ##

--- a/launch/waypoint_server.launch
+++ b/launch/waypoint_server.launch
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<launch>
+  <node name="waypoint_server" pkg="telecoV" type="waypoint_server_node.py" output="screen">
+    <param name="waypoint_filepath" value="$(find telecoV)/waypoints/waypoints.bin" />
+    <param name="reference_frame" value="map" />
+    <param name="robot_frame" value="base_link" />
+  </node>
+</launch>

--- a/msg/Waypoint.msg
+++ b/msg/Waypoint.msg
@@ -1,0 +1,2 @@
+string label
+geometry_msgs/PoseStamped pose

--- a/msg/WaypointArray.msg
+++ b/msg/WaypointArray.msg
@@ -1,0 +1,2 @@
+std_msgs/Header header
+telecoV/Waypoint[] waypoints

--- a/package.xml
+++ b/package.xml
@@ -1,93 +1,29 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>telecoV</name>
   <version>0.0.0</version>
   <description>The telecoV package</description>
-
-  <!-- One maintainer tag required, multiple allowed, one person per tag -->
-  <!-- Example:  -->
-  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
+  
   <maintainer email="nishimura.s405@gmail.com">niscode</maintainer>
 
-
-  <!-- One license tag required, multiple allowed, one license per tag -->
-  <!-- Commonly used license strings: -->
-  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
   <license>MIT</license>
 
-
-  <!-- Url tags are optional, but multiple are allowed, one per tag -->
-  <!-- Optional attribute type can be: website, bugtracker, or repository -->
-  <!-- Example: -->
-  <!-- <url type="website">http://wiki.ros.org/telecoV</url> -->
-
-
-  <!-- Author tags are optional, multiple are allowed, one per tag -->
-  <!-- Authors do not have to be maintainers, but could be -->
-  <!-- Example: -->
-  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
-
-
-  <!-- The *depend tags are used to specify dependencies -->
-  <!-- Dependencies can be catkin packages or system dependencies -->
-  <!-- Examples: -->
-  <!-- Use depend as a shortcut for packages that are both build and exec dependencies -->
-  <!--   <depend>roscpp</depend> -->
-  <!--   Note that this is equivalent to the following: -->
-  <!--   <build_depend>roscpp</build_depend> -->
-  <!--   <exec_depend>roscpp</exec_depend> -->
-  <!-- Use build_depend for packages you need at compile time: -->
-  <!--   <build_depend>message_generation</build_depend> -->
-  <!-- Use build_export_depend for packages you need in order to build against this package: -->
-  <!--   <build_export_depend>message_generation</build_export_depend> -->
-  <!-- Use buildtool_depend for build tool packages: -->
-  <!--   <buildtool_depend>catkin</buildtool_depend> -->
-  <!-- Use exec_depend for packages you need at runtime: -->
-  <!--   <exec_depend>message_runtime</exec_depend> -->
-  <!-- Use test_depend for packages you need only for testing: -->
-  <!--   <test_depend>gtest</test_depend> -->
-  <!-- Use doc_depend for packages you need only for building documentation: -->
-  <!--   <doc_depend>doxygen</doc_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend>nav_msgs</build_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>rospy</build_depend>
-  <build_depend>sensor_msgs</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>tf</build_depend>
-  <build_depend>tf2</build_depend>
-  <build_depend>urdf</build_depend>
-  <build_depend>xacro</build_depend>
-  <build_depend>qtbase5-dev</build_depend>
-  <build_depend>rviz</build_depend>
 
-  <build_export_depend>geometry_msgs</build_export_depend>
-  <build_export_depend>nav_msgs</build_export_depend>
-  <build_export_depend>roscpp</build_export_depend>
-  <build_export_depend>rospy</build_export_depend>
-  <build_export_depend>sensor_msgs</build_export_depend>
-  <build_export_depend>std_msgs</build_export_depend>
-  <build_export_depend>tf</build_export_depend>
-  <build_export_depend>tf2</build_export_depend>
-  <build_export_depend>urdf</build_export_depend>
-  <build_export_depend>xacro</build_export_depend>
-
-  <exec_depend>geometry_msgs</exec_depend>
-  <exec_depend>nav_msgs</exec_depend>
-  <exec_depend>roscpp</exec_depend>
-  <exec_depend>rospy</exec_depend>
-  <exec_depend>sensor_msgs</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
-  <exec_depend>tf</exec_depend>
-  <exec_depend>tf2</exec_depend>
-  <exec_depend>urdf</exec_depend>
-  <exec_depend>xacro</exec_depend>
-  <exec_depend>libqt5-core</exec_depend>
-  <exec_depend>libqt5-gui</exec_depend>
-  <exec_depend>libqt5-widgets</exec_depend>
-  <exec_depend>rviz</exec_depend>
-
+  <depend>roscpp</depend>
+  <depend>rospy</depend>
+  <depend>geometry_msgs</depend>
+  <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
+  <depend>nav_msgs</depend>
+  <depend>tf</depend>
+  <depend>tf2</depend>
+  <depend>urdf</depend>
+  <depend>xacro</depend>
+  <depend>libqt5-core</depend>
+  <depend>libqt5-gui</depend>
+  <depend>libqt5-widgets</depend>
+  <depend>rviz</depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/scripts/safety_watchdog_node.py
+++ b/scripts/safety_watchdog_node.py
@@ -50,7 +50,8 @@ class SafetyWatchdog:
         return False
 
     def _move_base_status_cb(self, msg: GoalStatusArray) -> None:
-        self._current_status = msg.status_list[-1].status
+        if msg.status_list:
+            self._current_status = msg.status_list[-1].status
 
     def _laser_scan_cb(self, msg: LaserScan) -> None:
         self._minimum_laser_range = min(msg.ranges)

--- a/scripts/safety_watchdog_node.py
+++ b/scripts/safety_watchdog_node.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import rospy
+from std_srvs.srv import Empty
+from sensor_msgs.msg import LaserScan
+from actionlib_msgs.msg import GoalID, GoalStatusArray, GoalStatus
+from move_base_msgs.msg import MoveBaseActionGoal
+from xmlrpc.client import ServerProxy as XMLServerProxy
+
+PROXIMITY_THRESHOLD = 0.5
+COOLDOWN_AFTER_TRIGGER = 5.0
+MAX_RETRIES = 5
+
+
+class SafetyWatchdog:
+    def __init__(self) -> None:
+        rospy.init_node("safety_watchdog_node")
+        self._ros_master = XMLServerProxy(os.environ['ROS_MASTER_URI'])
+        self._rosnode_dynamically_loaded = __import__('rosnode')
+
+        if not self._wait_for_node('/move_base', 10.0):
+            rospy.logerr('move_base node not available')
+            sys.exit(0)
+
+        rospy.Subscriber('/scan', LaserScan, self._laser_scan_cb, queue_size=1)
+        rospy.Subscriber('/move_base/status', GoalStatusArray, self._move_base_status_cb, queue_size=1)
+        rospy.Subscriber('/move_base/goal', MoveBaseActionGoal, self._move_base_goal_cb, queue_size=1)
+        self._navigation_cancel_publisher = rospy.Publisher('/move_base/cancel', GoalID, queue_size=10)
+        self._move_base_goal_publisher = rospy.Publisher('/move_base/goal', MoveBaseActionGoal, queue_size=1)
+        self._clear_costmap_service = rospy.ServiceProxy('/move_base/clear_costmaps', Empty)
+
+        self._current_status = GoalStatus.SUCCEEDED
+        self._latest_goal = MoveBaseActionGoal()
+        self._minimum_laser_range = -1.0
+        self._current_retry = 1
+        self._goal_header_id_during_incident = 0
+
+        rospy.loginfo('Safety_Watchdog started')
+
+    def _wait_for_node(self, node_name: str, timeout: float) -> bool:
+        start_time = rospy.Time.now().to_sec()
+        while start_time + timeout >= rospy.Time.now().to_sec():
+            try:
+                if node_name in self._rosnode_dynamically_loaded.get_node_names():
+                    return True
+            except self._rosnode_dynamically_loaded.ROSNodeIOException:
+                return False
+        return False
+
+    def _move_base_status_cb(self, msg: GoalStatusArray) -> None:
+        self._current_status = msg.status_list[-1].status
+
+    def _laser_scan_cb(self, msg: LaserScan) -> None:
+        self._minimum_laser_range = min(msg.ranges)
+
+    def _move_base_goal_cb(self, msg: MoveBaseActionGoal) -> None:
+        self._latest_goal = msg
+
+    def _cancel_navigation(self) -> None:
+        rospy.loginfo(f'Obstacle appeared in a distance of {self._minimum_laser_range}... Canceling navigation.. waiting for {COOLDOWN_AFTER_TRIGGER}s')
+        empty_goal = GoalID()
+        for i in range(5):
+            self._navigation_cancel_publisher.publish(empty_goal)
+
+    def _clear_costmap(self) -> None:
+        rospy.loginfo('Clearing costmap')
+        self._clear_costmap_service()
+
+    def _resend_goal(self) -> None:
+        rospy.loginfo(f'Resending move_base goal {self._current_retry}/{MAX_RETRIES}')
+        self._move_base_goal_publisher.publish(self._latest_goal)
+
+    def _check_if_retry(self) -> bool:
+        if self._latest_goal.goal.target_pose.header.seq == self._goal_header_id_during_incident and self._current_retry < MAX_RETRIES:
+            self._current_retry += 1
+            return True
+        if self._latest_goal.goal.target_pose.header.seq != self._goal_header_id_during_incident:
+            self._goal_header_id_during_incident = self._latest_goal.goal.target_pose.header.seq
+            self._current_retry = 1
+            return True
+        rospy.logwarn(f'Used all {MAX_RETRIES} retries for this goal. Giving up navigation.')
+        return False
+
+    def _log_current_status(self) -> None:
+        if self._current_status == GoalStatus.ACTIVE:
+            rospy.loginfo_throttle(0.5, f'Robot currently moving')
+        elif self._current_status == GoalStatus.SUCCEEDED:
+            rospy.loginfo_throttle(0.5, f'Robot navigation successful')
+        else:
+            rospy.loginfo_throttle(0.5, f'move_base status {self._current_status}')
+
+    def run(self) -> None:
+        rate = rospy.Rate(10)
+        while not rospy.is_shutdown():
+            if self._current_status == GoalStatus.ACTIVE and self._minimum_laser_range < PROXIMITY_THRESHOLD:
+                self._cancel_navigation()
+                rospy.sleep(COOLDOWN_AFTER_TRIGGER)
+                self._clear_costmap()
+                if self._check_if_retry():
+                    self._resend_goal()
+            rate.sleep()
+
+
+if __name__ == '__main__':
+    try:
+        sw = SafetyWatchdog()
+        sw.run()
+    except rospy.ROSInterruptException:
+        pass

--- a/scripts/waypoint_server_node.py
+++ b/scripts/waypoint_server_node.py
@@ -184,6 +184,7 @@ class WaypointServer:
             name = f'{prefix}{random.randrange(100)}'
         wp = Waypoint(name, PoseStamped(Header(), Pose(msg.point, Quaternion())))
         wp.pose.header.frame_id = 'map'
+        wp.pose.pose.orientation.w = 1.0
         self._waypoints[name] = wp
         self._mh.add_goal_pose_marker(wp.pose, wp.label)
         self._publish_waypoints()
@@ -194,7 +195,10 @@ class WaypointServer:
                 ret = pickle.load(infile)
                 return ret
         except FileNotFoundError:
-            return {INITIAL_POSITION_NAME: Waypoint('init', PoseStamped())}
+            pose = PoseStamped(Header(), Pose())
+            pose.header.frame_id = 'map'
+            pose.pose.orientation.w = 1.0
+            return {INITIAL_POSITION_NAME: Waypoint(INITIAL_POSITION_NAME, pose)}
 
     def _save_waypoints(self, path: str, waypoints: Dict[str, Waypoint]) -> None:
         with open(path, 'wb') as outfile:
@@ -206,6 +210,7 @@ class WaypointServer:
             return
         wp = Waypoint(name, PoseStamped())
         wp.pose.header.frame_id = 'map'
+        wp.pose.pose.orientation.w = 1.0
         self._waypoints[name] = wp
         self._mh.add_goal_pose_marker(wp.pose, wp.label)
         self._publish_waypoints()

--- a/scripts/waypoint_server_node.py
+++ b/scripts/waypoint_server_node.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import copy
+import pickle
+from typing import Dict
+import rospy
+from telecoV.msg import Waypoint, WaypointArray
+from geometry_msgs.msg import Pose, PoseStamped, Quaternion
+from std_srvs.srv import Empty
+from actionlib_msgs.msg import GoalID
+from move_base_msgs.msg import MoveBaseActionGoal
+from interactive_markers.interactive_marker_server import *
+from interactive_markers.menu_handler import *
+from visualization_msgs.msg import *
+from geometry_msgs.msg import Point
+
+DEFAULT_PATH = '/home/arne/waypoints.bin'
+initial_position_name = 'init'
+
+
+class WaypointMarkerHandler:
+    def __init__(self, change_callback=None):
+        self._server = InteractiveMarkerServer("waypoint_marker_handler")
+        self._menu_handler = MenuHandler()
+        self._menu_handler.insert("Navigate Here", callback=self._process_feedback)
+        self._menu_handler.insert("Remove", callback=self._process_feedback)
+
+        self._marker_changed_callback = change_callback
+        self._server.applyChanges()
+
+    def _process_feedback(self, feedback: InteractiveMarkerFeedback) -> None:
+        self._marker_changed_callback(feedback)
+        self._server.applyChanges()
+
+    def _make_marker(self, msg: InteractiveMarker) -> Marker:
+        marker = Marker()
+        marker.type = Marker.ARROW
+        marker.scale.x = msg.scale * 0.5
+        marker.scale.y = msg.scale * 0.1
+        marker.scale.z = msg.scale * 0.1
+        marker.color.r = 1.0
+        marker.color.g = 0.0
+        marker.color.b = 1.0
+        marker.color.a = 1.0
+        return marker
+
+    def _make_box_control(self, msg: InteractiveMarker) -> InteractiveMarkerControl:
+        control = InteractiveMarkerControl()
+        control.always_visible = True
+        control.markers.append(self._make_marker(msg))
+        msg.controls.append(control)
+        return control
+
+    def _normalize_quaternion(self, quaternion_msg: Quaternion) -> None:
+        norm = quaternion_msg.x ** 2 + quaternion_msg.y ** 2 + quaternion_msg.z ** 2 + quaternion_msg.w ** 2
+        s = norm ** (-0.5)
+        quaternion_msg.x *= s
+        quaternion_msg.y *= s
+        quaternion_msg.z *= s
+        quaternion_msg.w *= s
+
+    def add_goal_pose_marker(self, initial_pose: PoseStamped, label: str) -> None:
+        int_marker = InteractiveMarker()
+        int_marker.header.frame_id = "map"
+        int_marker.pose = initial_pose.pose
+        int_marker.scale = 1
+
+        int_marker.name = label
+        int_marker.description = label
+
+        self._make_box_control(int_marker)
+        int_marker.controls[0].interaction_mode = InteractiveMarkerControl.NONE
+
+        control = InteractiveMarkerControl()
+        control.orientation.w = 1
+        control.orientation.x = 1
+        control.orientation.y = 0
+        control.orientation.z = 0
+        self._normalize_quaternion(control.orientation)
+        control.name = "move_x"
+        control.interaction_mode = InteractiveMarkerControl.MOVE_AXIS
+        int_marker.controls.append(copy.deepcopy(control))
+
+        control = InteractiveMarkerControl()
+        control.orientation.w = 1
+        control.orientation.x = 0
+        control.orientation.y = 0
+        control.orientation.z = 1
+        self._normalize_quaternion(control.orientation)
+        control.name = "move_y"
+        control.interaction_mode = InteractiveMarkerControl.MOVE_AXIS
+        int_marker.controls.append(copy.deepcopy(control))
+
+        control = InteractiveMarkerControl()
+        control.orientation.w = 1
+        control.orientation.x = 0
+        control.orientation.y = 1
+        control.orientation.z = 0
+        self._normalize_quaternion(control.orientation)
+        control.name = "rotate_z"
+        control.interaction_mode = InteractiveMarkerControl.ROTATE_AXIS
+        int_marker.controls.append(copy.deepcopy(control))
+
+        # BUG: Mixing InteractiveMarkerControl.MOVE_PLANE with InteractiveMarkerControl.ROTATE_AXIS controls screws up marker interaction
+        # control = InteractiveMarkerControl()
+        # control.orientation.w = 1
+        # control.orientation.x = 0
+        # control.orientation.y = 1
+        # control.orientation.z = 0
+        # normalizeQuaternion(control.orientation)
+        # control.name = "move_plane"
+        # control.interaction_mode = InteractiveMarkerControl.MOVE_PLANE
+        # int_marker.controls.append(copy.deepcopy(control))
+
+        self._server.insert(int_marker, self._process_feedback)
+        self._menu_handler.apply(self._server, int_marker.name)
+        self._server.applyChanges()
+
+    def remove_goal_marker(self, label: str) -> None:
+        self._server.erase(label)
+
+
+class WaypointServer:
+    def __init__(self) -> None:
+        rospy.init_node("waypoint_server_node")
+        rospy.on_shutdown(self._shutdown_hook)
+        rospy.loginfo('Waypoint_Server started')
+        self._waypoints = self._load_waypoints(DEFAULT_PATH)
+
+        self._navigation_cancel_publisher = rospy.Publisher('/move_base/cancel', GoalID, queue_size=10)
+        self._navigation_goal_publisher = rospy.Publisher('/move_base/goal', MoveBaseActionGoal, queue_size=10)
+
+        self._shortcut_mapping = {'add': (self._add_waypoint, 'Add waypoint at 0,0,0 with name of argument', 1),
+                                  'remove': (self._remove_waypoint, 'Removes waypoint with name of argument', 1),
+                                  'list': (self._list_waypoints, 'Lists all waypoints', 0),
+                                  'stop': (self._stop_navigation, 'Stops current navigation', 0),
+                                  'cls': (self._clear_screen, 'Clear screen', 0),
+                                  'quit': (self._end_program, 'Quit', 0)
+                                  }
+
+        self._mh = WaypointMarkerHandler(change_callback=self._marker_changed_cb)
+        for w in self._waypoints:
+            waypoint = self._waypoints[w]
+            self._mh.add_goal_pose_marker(waypoint.pose, str(waypoint.label))
+
+        self._running = True
+
+    def _shutdown_hook(self) -> None:
+        self._save_waypoints(DEFAULT_PATH, self._waypoints)
+
+    def _marker_changed_cb(self, feedback: InteractiveMarkerFeedback) -> None:
+        if feedback.event_type == InteractiveMarkerFeedback.MENU_SELECT:
+            if feedback.menu_entry_id == 1:
+                self._send_navigation_goal(feedback.marker_name)
+            elif feedback.menu_entry_id == 2:
+                self._remove_waypoint(feedback.marker_name)
+        if feedback.event_type == InteractiveMarkerFeedback.POSE_UPDATE:
+            self._update_waypoint(feedback.marker_name, feedback.pose)
+
+    def _load_waypoints(self, path: str) -> Dict[str, Waypoint]:
+        try:
+            with open(path, 'rb') as infile:
+                ret = pickle.load(infile)
+                return ret
+        except FileNotFoundError:
+            return {initial_position_name: Waypoint('init', PoseStamped())}
+
+    def _save_waypoints(self, path: str, waypoints: Dict[str, Waypoint]) -> None:
+        with open(path, 'wb') as outfile:
+            pickle.dump(waypoints, outfile)
+
+    def _add_waypoint(self, name: str) -> None:
+        if name in self._waypoints.keys():
+            print(f'Waypoint "{name}" aleady exists')
+            return
+        wp = Waypoint(name, PoseStamped())
+        wp.pose.header.frame_id = 'map'
+        self._waypoints[name] = wp
+        self._mh.add_goal_pose_marker(wp.pose, wp.label)
+
+    def _remove_waypoint(self, name: str) -> None:
+        try:
+            self._waypoints.pop(name)
+            self._mh.remove_goal_marker(name)
+        except KeyError:
+            print(f'Waypoint "{name}" doesn\'t exist')
+
+    def _update_waypoint(self, label, pose):
+        if label in self._waypoints:
+            self._waypoints[label].pose.pose = pose
+
+    def _stop_navigation(self) -> None:
+        print('Stopping navigation')
+        empty_goal = GoalID()
+        for i in range(5):
+            self._navigation_cancel_publisher.publish(empty_goal)
+
+    def _list_waypoints(self):
+        for w in self._waypoints.keys():
+            print(f'{w} -> [x:{self._waypoints[w].pose.pose.position.x}, y:{self._waypoints[w].pose.pose.position.y}, z:{self._waypoints[w].pose.pose.position.z}]')
+
+    def _end_program(self) -> None:
+        self._shutdown_hook()
+        print('Exiting.....')
+        self._clear_screen()
+        self._running = False
+
+    def _clear_screen(self) -> None:
+        os.system('clear')
+
+    def _send_navigation_goal(self, waypoint_label) -> None:
+        move_base_goal = MoveBaseActionGoal()
+        move_base_goal.header = Header()
+        move_base_goal.goal.target_pose = self._waypoints[waypoint_label].pose
+        move_base_goal.goal.target_pose.header.frame_id = 'map'
+        self._navigation_goal_publisher.publish(move_base_goal)
+
+    def _help(self) -> None:
+        print('Usage: command [argument]')
+        for k in self._shortcut_mapping:
+            print(f'{k}\t-> {self._shortcut_mapping[k][1]}')
+
+    def run(self) -> None:
+        while self._running:
+            print('>>> ', end='')
+            val = input()
+            try:
+                args = val.split(' ')
+                mapping = self._shortcut_mapping[args[0]]
+                if mapping[2] == 0:
+                    mapping[0]()
+                elif mapping[2] == 1:
+                    mapping[0](args[1])
+            except (KeyError, AttributeError, IndexError):
+                self._help()
+
+
+if __name__ == '__main__':
+    try:
+        ws = WaypointServer()
+        ws.run()
+    except rospy.ROSInterruptException:
+        pass

--- a/scripts/waypoint_server_node.py
+++ b/scripts/waypoint_server_node.py
@@ -236,7 +236,8 @@ class WaypointServer:
 
     def _rename_waypoint(self, source: str, destination: str) -> None:
         if destination in self._waypoints:
-            print(f'Waypoint "{destination}" doesn\'t exist')
+            print(f'Waypoint "{destination}" already exists')
+            return
         try:
             wp = self._waypoints.pop(source)
             self._mh.remove_goal_marker(source)


### PR DESCRIPTION
This node monitors the combined LaserScan messages on the /scan topic as well as the current state of the move_base node.
In the case that the robot is navigating and the an unexpected obstacle appears within a given proximity threshold, the node cancels the current navigation attempt.
It then waits, clears the costmaps and resend the navigation goal for an additional attempt.
The node will do so for a given number of times. If the max retry count is reached, no the goal will not be send again so that the robot gives up on this navigation goal.
This should make sure that no humans who approach the robot quicker than it can avoid them will be hit.